### PR TITLE
fix: cast exception on version

### DIFF
--- a/src/main/java/io/kestra/plugin/confluence/pages/Update.java
+++ b/src/main/java/io/kestra/plugin/confluence/pages/Update.java
@@ -137,10 +137,28 @@ public class Update extends AbstractConfluenceTask implements RunnableTask<Updat
         Map<String, Object> rVersionMap = runContext.render(this.versionInfo)
             .asMap(String.class, Object.class);
 
-        Integer numberObj = (Integer) rVersionMap.get("number");
-        String messageObj = (String) rVersionMap.get("message");
-        if (numberObj == null || messageObj == null) {
-            throw new IllegalArgumentException("versionInfo.number and versionInfo.message are required");
+        Object numberRaw = rVersionMap.get("number");
+        Object messageRaw = rVersionMap.get("message");
+
+        Integer numberObj;
+        if (numberRaw == null) {
+            throw new IllegalArgumentException("versionInfo.number is required");
+        }
+
+        if (numberRaw instanceof Number n) {
+            numberObj = n.intValue();
+        } else {
+            String s = numberRaw.toString().trim();
+            if (s.matches("^-?\\d+(\\.0+)?$")) {
+                numberObj = (int) Double.parseDouble(s);
+            } else {
+                throw new IllegalArgumentException("versionInfo.number must be an integer, got: " + s);
+            }
+        }
+
+        String messageObj = messageRaw == null ? null : messageRaw.toString();
+        if (messageObj == null || messageObj.isBlank()) {
+            throw new IllegalArgumentException("versionInfo.message is required");
         }
 
         MutableDataSet options = new MutableDataSet();

--- a/src/test/java/io/kestra/plugin/pages/UpdateTest.java
+++ b/src/test/java/io/kestra/plugin/pages/UpdateTest.java
@@ -6,13 +6,21 @@ import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.plugin.confluence.pages.Update;
 import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayOutputStream;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -47,6 +55,113 @@ class UpdateTest {
     }
 
     @Test
+    void missingVersionNumber_throws() {
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        Update task = Update.builder()
+            .serverUrl(Property.ofValue("https://example.com"))
+            .username(Property.ofValue("user@example.com"))
+            .apiToken(Property.ofValue("token"))
+            .pageId(Property.ofValue("123"))
+            .status(Property.ofValue("current"))
+            .title(Property.ofValue("Title"))
+            .markdown(Property.ofValue("# Hello"))
+            .versionInfo(Property.ofValue(Map.of(
+                "message", "msg"
+            )))
+            .build();
+
+        assertThrows(IllegalArgumentException.class, () -> task.run(runContext));
+    }
+
+    @Test
+    void missingVersionMessage_throws() {
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        Update task = Update.builder()
+            .serverUrl(Property.ofValue("https://example.com"))
+            .username(Property.ofValue("user@example.com"))
+            .apiToken(Property.ofValue("token"))
+            .pageId(Property.ofValue("123"))
+            .status(Property.ofValue("current"))
+            .title(Property.ofValue("Title"))
+            .markdown(Property.ofValue("# Hello"))
+            .versionInfo(Property.ofValue(Map.of(
+                "number", 2
+            )))
+            .build();
+
+        assertThrows(IllegalArgumentException.class, () -> task.run(runContext));
+    }
+
+    @Test
+    void blankVersionMessage_throws() {
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        Update task = Update.builder()
+            .serverUrl(Property.ofValue("https://example.com"))
+            .username(Property.ofValue("user@example.com"))
+            .apiToken(Property.ofValue("token"))
+            .pageId(Property.ofValue("123"))
+            .status(Property.ofValue("current"))
+            .title(Property.ofValue("Title"))
+            .markdown(Property.ofValue("# Hello"))
+            .versionInfo(Property.ofValue(Map.of(
+                "number", 2,
+                "message", "   "
+            )))
+            .build();
+
+        assertThrows(IllegalArgumentException.class, () -> task.run(runContext));
+    }
+
+    @Test
+    void invalidVersionNumberString_throws() {
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        Update task = Update.builder()
+            .serverUrl(Property.ofValue("https://example.com"))
+            .username(Property.ofValue("user@example.com"))
+            .apiToken(Property.ofValue("token"))
+            .pageId(Property.ofValue("123"))
+            .status(Property.ofValue("current"))
+            .title(Property.ofValue("Title"))
+            .markdown(Property.ofValue("# Hello"))
+            .versionInfo(Property.ofValue(Map.of(
+                "number", "four",
+                "message", "msg"
+            )))
+            .build();
+
+        assertThrows(IllegalArgumentException.class, () -> task.run(runContext));
+    }
+
+    @Test
+    void versionNumberAsStringInteger_isParsedAndSent() throws Exception {
+        assertVersionNumberIsRenderedAsJsonNumber("4");
+    }
+
+    @Test
+    void versionNumberAsStringDecimal_isParsedAndSent() throws Exception {
+        assertVersionNumberIsRenderedAsJsonNumber("4.0");
+    }
+
+    @Test
+    void versionNumberAsLong_isParsedAndSent() throws Exception {
+        assertVersionNumberIsRenderedAsJsonNumber(4L);
+    }
+
+    @Test
+    void versionNumberAsDouble_isParsedAndSent() throws Exception {
+        assertVersionNumberIsRenderedAsJsonNumber(4.0d);
+    }
+
+    @Test
+    void versionNumberAsInteger_isSent() throws Exception {
+        assertVersionNumberIsRenderedAsJsonNumber(4);
+    }
+
+    @Test
     void non2xxResponse_throwsIllegalStateException() throws Exception {
         RunContext runContext = runContextFactory.of(Map.of());
 
@@ -65,7 +180,6 @@ class UpdateTest {
             .build();
 
         HttpClient httpClientMock = Mockito.mock(HttpClient.class);
-        HttpClient.Builder builderMock = Mockito.mock(HttpClient.Builder.class);
         HttpResponse<String> httpResponseMock = Mockito.mock(HttpResponse.class);
 
         try (MockedStatic<HttpClient> httpClientStatic = Mockito.mockStatic(HttpClient.class)) {
@@ -123,5 +237,92 @@ class UpdateTest {
             assertThat(output.getValue(), is(notNullValue()));
             assertThat(output.getValue(), containsString("\"id\":\"123\""));
         }
+    }
+
+    private void assertVersionNumberIsRenderedAsJsonNumber(Object rawNumber) throws Exception {
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        Update task = Update.builder()
+            .serverUrl(Property.ofValue("https://example.com"))
+            .username(Property.ofValue("user@example.com"))
+            .apiToken(Property.ofValue("token"))
+            .pageId(Property.ofValue("123"))
+            .status(Property.ofValue("current"))
+            .title(Property.ofValue("Title"))
+            .markdown(Property.ofValue("# Hello"))
+            .versionInfo(Property.ofValue(Map.of(
+                "number", rawNumber,
+                "message", "msg"
+            )))
+            .build();
+
+        HttpClient httpClientMock = Mockito.mock(HttpClient.class);
+        HttpResponse<String> httpResponseMock = Mockito.mock(HttpResponse.class);
+
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+
+        try (MockedStatic<HttpClient> httpClientStatic = Mockito.mockStatic(HttpClient.class)) {
+            httpClientStatic.when(HttpClient::newHttpClient).thenReturn(httpClientMock);
+
+            when(httpResponseMock.statusCode()).thenReturn(200);
+            when(httpResponseMock.body()).thenReturn("{\"ok\":true}");
+
+            when(httpClientMock.send(
+                requestCaptor.capture(),
+                eq(HttpResponse.BodyHandlers.ofString())
+            )).thenReturn(httpResponseMock);
+
+            task.run(runContext);
+
+            HttpRequest sent = requestCaptor.getValue();
+            assertThat(sent, is(notNullValue()));
+
+            String body = readBody(sent);
+            assertThat(body, is(notNullValue()));
+
+            assertThat(body, containsString("\"version\""));
+            assertThat(body, containsString("\"number\":" + 4));
+            assertThat(body, not(containsString("\"number\":\"" + 4 + "\"")));
+            assertThat(body, containsString("\"message\":\"msg\""));
+        }
+    }
+
+    private static String readBody(HttpRequest request) throws Exception {
+        var publisherOpt = request.bodyPublisher();
+        if (publisherOpt.isEmpty()) {
+            return "";
+        }
+
+        HttpRequest.BodyPublisher publisher = publisherOpt.get();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CompletableFuture<Void> done = new CompletableFuture<>();
+
+        publisher.subscribe(new Flow.Subscriber<>() {
+
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                subscription.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(ByteBuffer item) {
+                byte[] buf = new byte[item.remaining()];
+                item.get(buf);
+                out.writeBytes(buf);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                done.completeExceptionally(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                done.complete(null);
+            }
+        });
+
+        done.get(); // block until complete
+        return out.toString(StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
fixes https://github.com/kestra-io/plugin-confluence/issues/10 

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Every time you use `runContext.metric(...)` you have to add a `@Metric` ([see this doc](https://kestra.io/docs/plugin-developer-guide/document#document-the-plugin-metrics))
- [ ] Docs don't support to have both tasks/triggers in the root package (e.g. `io.kestra.plugin.kubernetes`) and in a sub package (e.g. `io.kestra.plugin.kubernetes.kubectl`), whether it's: all tasks/triggers in the root package OR only tasks/triggers in sub packages.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.
- [ ] Update the existing `index.yaml` for the main plugin, and for each new subpackage add a metadata file named exactly after the subpackage (e.g. `s3.yaml` for `io.kestra.plugin.aws.s3`) under `src/main/resources/metadata/`, following the same schema.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (to be set executable with `chmod +x setup-unit.sh`) (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`). If needed, create an executable (`chmod +x cleanup-unit.sh`) `cleanup-unit.sh` to remove the potential costly resources (tables, datasets, etc).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).