### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/confluence/AbstractConfluenceTask.java
+++ b/src/main/java/io/kestra/plugin/confluence/AbstractConfluenceTask.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -22,6 +23,7 @@ public abstract class AbstractConfluenceTask extends Task {
         description = "Base Confluence site URL (e.g., https://your-domain.atlassian.net) without a trailing slash; /wiki/api/v2 is appended automatically."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> serverUrl;
 
     @Schema(
@@ -29,6 +31,7 @@ public abstract class AbstractConfluenceTask extends Task {
         description = "Confluence account email used for Basic authentication; render from secrets where possible."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> username;
 
     @Schema(
@@ -36,5 +39,6 @@ public abstract class AbstractConfluenceTask extends Task {
         description = "Atlassian API token associated with the username; keep in a secret and avoid logging."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> apiToken;
 }

--- a/src/main/java/io/kestra/plugin/confluence/pages/Create.java
+++ b/src/main/java/io/kestra/plugin/confluence/pages/Create.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -67,52 +68,61 @@ public class Create extends AbstractConfluenceTask implements RunnableTask<Creat
         title = "Create content as embedded",
         description = "Sets `embedded=true` so Confluence stores the page in the new content service. Default: false"
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> embedded;
 
     @Schema(
         title = "Make page private",
         description = "If true, only the creator can view and edit the page until permissions are changed. Default: false"
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> makePrivate;
 
     @Schema(
         title = "Create page at space root",
         description = "Creates the page at the space root (outside the homepage tree) and forbids parentId. Default: false"
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> rootLevel;
 
     @Schema(title = "Target space ID", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> spaceId;
 
     @Schema(
         title = "Page status",
         description = "Optional page status. Valid values: `current`, `draft`. Confluence applies its default when omitted."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> status;
 
     @Schema(
         title = "Page title",
         description = "Display title for the new Confluence page."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> title;
 
     @Schema(
         title = "Parent page ID",
         description = "Parent content ID. When rootLevel is false and omitted, Confluence uses the space homepage; ignored when rootLevel is true."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> parentId;
 
     @Schema(
         title = "Markdown content to upload",
         description = "Markdown rendered to Confluence storage HTML before sending to the API."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> markdown;
 
     @Schema(
         title = "Page subtype",
         description = "Optional subtype. Use `live` to create a collaborative live doc; omit for a regular page."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> subtype;
 
     @Override

--- a/src/main/java/io/kestra/plugin/confluence/pages/List.java
+++ b/src/main/java/io/kestra/plugin/confluence/pages/List.java
@@ -33,6 +33,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -79,6 +80,7 @@ public class List extends AbstractConfluenceTask implements RunnableTask<List.Ou
         title = "Sort order of results",
         description = "Specify sorting of the result set. Valid values: id, -id, created-date, -created-date, modified-date, -modified-date, title, -title."
     )
+    @PluginProperty(group = "processing")
     private Property<String> sort;
 
     @Schema(
@@ -92,18 +94,21 @@ public class List extends AbstractConfluenceTask implements RunnableTask<List.Ou
         title = "Page title filter",
         description = "Filter results to pages that exactly match this title."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> title;
 
     @Schema(
         title = "Page subtype filter",
         description = "Filter by page subtype. Valid values: live (collaborative draft/live page), page (regular page)."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> subType;
 
     @Schema(
         title = "Pagination cursor",
         description = "Opaque cursor returned in the Link response header; pass it to fetch the next page of results."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> cursor;
 
     @Schema(
@@ -118,6 +123,7 @@ public class List extends AbstractConfluenceTask implements RunnableTask<List.Ou
         description = "Determines how results are returned. FETCH returns a list, FETCH_ONE limits to the first page, STORE writes all pages to internal storage and returns a URI. Default: FETCH."
     )
     @Builder.Default
+    @PluginProperty(group = "processing")
     private Property<FetchType> fetchType = Property.ofValue(FetchType.FETCH);
 
     @Override
@@ -293,6 +299,7 @@ public class List extends AbstractConfluenceTask implements RunnableTask<List.Ou
     @Getter
     public static class OutputChild implements io.kestra.core.models.tasks.Output {
         @Schema(title = "Page title")
+        @PluginProperty(group = "advanced")
         private final String title;
 
         @Schema(title = "Markdown content")

--- a/src/main/java/io/kestra/plugin/confluence/pages/Update.java
+++ b/src/main/java/io/kestra/plugin/confluence/pages/Update.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -67,6 +68,7 @@ public class Update extends AbstractConfluenceTask implements RunnableTask<Updat
         description = "Confluence page identifier to update; used in the request path."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> pageId;
 
     @Schema(
@@ -74,6 +76,7 @@ public class Update extends AbstractConfluenceTask implements RunnableTask<Updat
         description = "Required page status. Valid values: `current`, `draft`. Changing from current to draft deletes any existing draft."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> status;
 
     @Schema(
@@ -81,24 +84,28 @@ public class Update extends AbstractConfluenceTask implements RunnableTask<Updat
         description = "Updated page title."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> title;
 
     @Schema(
         title = "Space ID",
         description = "ID of the containing space; must stay within the current space because cross-space moves are not supported."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> spaceId;
 
     @Schema(
         title = "Parent page ID",
         description = "Parent content ID for re-parenting within the same space."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> parentId;
 
     @Schema(
         title = "Owner Account ID",
         description = "Account ID of the page owner; transfers ownership to another user."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> ownerId;
 
     @Schema(
@@ -106,6 +113,7 @@ public class Update extends AbstractConfluenceTask implements RunnableTask<Updat
         description = "Markdown rendered to Confluence storage HTML before sending to the API."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> markdown;
 
     @Schema(
@@ -113,6 +121,7 @@ public class Update extends AbstractConfluenceTask implements RunnableTask<Updat
         description = "Required version payload. Must include `number` (integer) and `message` (non-blank comment) for the new version."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<Map<String, Object>> versionInfo;
 
     @Override


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712