### PR TITLE
feat: add optional apiPath property for On-Premise support

### DIFF
--- a/src/main/java/io/kestra/plugin/confluence/AbstractConfluenceTask.java
+++ b/src/main/java/io/kestra/plugin/confluence/AbstractConfluenceTask.java
@@ -5,6 +5,7 @@ import io.kestra.core.models.tasks.Task;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,11 +21,19 @@ import io.kestra.core.models.annotations.PluginProperty;
 public abstract class AbstractConfluenceTask extends Task {
     @Schema(
         title = "Set Confluence site URL",
-        description = "Base Confluence site URL (e.g., https://your-domain.atlassian.net) without a trailing slash; /wiki/api/v2 is appended automatically."
+        description = "Base Confluence site URL (e.g., https://your-domain.atlassian.net) without a trailing slash."
     )
     @NotNull
     @PluginProperty(group = "main")
     protected Property<String> serverUrl;
+
+    @Schema(
+        title = "API base path",
+        description = "Base path appended to the server URL before the resource endpoint. Defaults to /wiki/api/v2 for Confluence Cloud. Override for On-Premise instances (e.g., /rest/api or a custom context root)."
+    )
+    @PluginProperty(group = "main")
+    @Builder.Default
+    protected Property<String> apiPath = Property.ofValue("/wiki/api/v2");
 
     @Schema(
         title = "Authentication username (email)",

--- a/src/main/java/io/kestra/plugin/confluence/AbstractConfluenceTask.java
+++ b/src/main/java/io/kestra/plugin/confluence/AbstractConfluenceTask.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.confluence;
 
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -50,4 +51,16 @@ public abstract class AbstractConfluenceTask extends Task {
     @NotNull
     @PluginProperty(group = "main")
     protected Property<String> apiToken;
+
+    protected String buildApiBaseUrl(RunContext runContext) throws Exception {
+        String server = runContext.render(this.serverUrl).as(String.class)
+            .orElseThrow(() -> new IllegalArgumentException("serverUrl is required"));
+        String path = runContext.render(this.apiPath).as(String.class)
+            .orElseThrow(() -> new IllegalArgumentException("apiPath is required"));
+        return stripTrailingSlash(server) + stripTrailingSlash(path);
+    }
+
+    private static String stripTrailingSlash(String s) {
+        return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
+    }
 }

--- a/src/main/java/io/kestra/plugin/confluence/pages/Create.java
+++ b/src/main/java/io/kestra/plugin/confluence/pages/Create.java
@@ -135,6 +135,7 @@ public class Create extends AbstractConfluenceTask implements RunnableTask<Creat
             .orElseThrow(() -> new IllegalArgumentException("username is required"));
         String rApiToken = runContext.render(this.apiToken).as(String.class)
             .orElseThrow(() -> new IllegalArgumentException("apiToken is required"));
+        String rApiPath = runContext.render(this.apiPath).as(String.class).orElse("/wiki/api/v2");
         String rSpaceId = runContext.render(this.spaceId).as(String.class)
             .orElseThrow(() -> new IllegalArgumentException("spaceId is required"));
         String rTitle = runContext.render(this.title).as(String.class)
@@ -180,7 +181,8 @@ public class Create extends AbstractConfluenceTask implements RunnableTask<Creat
         String encodedAuth = Base64.getEncoder().encodeToString(authString.getBytes(StandardCharsets.UTF_8));
 
         String base = rServerUrl.endsWith("/") ? rServerUrl.substring(0, rServerUrl.length() - 1) : rServerUrl;
-        String url = base + "/wiki/api/v2/pages";
+        String apiBase = rApiPath.endsWith("/") ? rApiPath.substring(0, rApiPath.length() - 1) : rApiPath;
+        String url = base + apiBase + "/pages";
 
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder()

--- a/src/main/java/io/kestra/plugin/confluence/pages/Create.java
+++ b/src/main/java/io/kestra/plugin/confluence/pages/Create.java
@@ -129,13 +129,11 @@ public class Create extends AbstractConfluenceTask implements RunnableTask<Creat
     public Create.Output run(RunContext runContext) throws Exception {
         var logger = runContext.logger();
 
-        String rServerUrl = runContext.render(this.serverUrl).as(String.class)
-            .orElseThrow(() -> new IllegalArgumentException("serverUrl is required"));
+        String apiBaseUrl = buildApiBaseUrl(runContext);
         String rUsername = runContext.render(this.username).as(String.class)
             .orElseThrow(() -> new IllegalArgumentException("username is required"));
         String rApiToken = runContext.render(this.apiToken).as(String.class)
             .orElseThrow(() -> new IllegalArgumentException("apiToken is required"));
-        String rApiPath = runContext.render(this.apiPath).as(String.class).orElse("/wiki/api/v2");
         String rSpaceId = runContext.render(this.spaceId).as(String.class)
             .orElseThrow(() -> new IllegalArgumentException("spaceId is required"));
         String rTitle = runContext.render(this.title).as(String.class)
@@ -180,9 +178,7 @@ public class Create extends AbstractConfluenceTask implements RunnableTask<Creat
         String authString = rUsername + ":" + rApiToken;
         String encodedAuth = Base64.getEncoder().encodeToString(authString.getBytes(StandardCharsets.UTF_8));
 
-        String base = rServerUrl.endsWith("/") ? rServerUrl.substring(0, rServerUrl.length() - 1) : rServerUrl;
-        String apiBase = rApiPath.endsWith("/") ? rApiPath.substring(0, rApiPath.length() - 1) : rApiPath;
-        String url = base + apiBase + "/pages";
+        String url = apiBaseUrl + "/pages";
 
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder()

--- a/src/main/java/io/kestra/plugin/confluence/pages/List.java
+++ b/src/main/java/io/kestra/plugin/confluence/pages/List.java
@@ -132,13 +132,11 @@ public class List extends AbstractConfluenceTask implements RunnableTask<List.Ou
         FlexmarkHtmlConverter converter = FlexmarkHtmlConverter.builder().build();
         java.util.List<OutputChild> markdownPages = new ArrayList<>();
 
-        String rServerUrl = runContext.render(this.serverUrl).as(String.class)
-            .orElseThrow(() -> new IllegalArgumentException("serverUrl is required"));
+        String apiBaseUrl = buildApiBaseUrl(runContext);
         String rUsername = runContext.render(this.username).as(String.class)
             .orElseThrow(() -> new IllegalArgumentException("username is required"));
         String rApiToken = runContext.render(this.apiToken).as(String.class)
             .orElseThrow(() -> new IllegalArgumentException("apiToken is required"));
-        String rApiPath = runContext.render(this.apiPath).as(String.class).orElse("/wiki/api/v2");
 
         java.util.List<Integer> rSpaceIds = runContext.render(this.spaceIds).asList(Integer.class);
         java.util.List<Integer> rPageIds = runContext.render(this.pageIds).asList(Integer.class);
@@ -193,9 +191,7 @@ public class List extends AbstractConfluenceTask implements RunnableTask<List.Ou
             )
             .collect(Collectors.joining("&"));
 
-        String base = rServerUrl.endsWith("/") ? rServerUrl.substring(0, rServerUrl.length() - 1) : rServerUrl;
-        String apiBase = rApiPath.endsWith("/") ? rApiPath.substring(0, rApiPath.length() - 1) : rApiPath;
-        String url = base + apiBase + "/pages";
+        String url = apiBaseUrl + "/pages";
         if (!query.isEmpty()) {
             url += "?" + query;
         }

--- a/src/main/java/io/kestra/plugin/confluence/pages/List.java
+++ b/src/main/java/io/kestra/plugin/confluence/pages/List.java
@@ -138,6 +138,7 @@ public class List extends AbstractConfluenceTask implements RunnableTask<List.Ou
             .orElseThrow(() -> new IllegalArgumentException("username is required"));
         String rApiToken = runContext.render(this.apiToken).as(String.class)
             .orElseThrow(() -> new IllegalArgumentException("apiToken is required"));
+        String rApiPath = runContext.render(this.apiPath).as(String.class).orElse("/wiki/api/v2");
 
         java.util.List<Integer> rSpaceIds = runContext.render(this.spaceIds).asList(Integer.class);
         java.util.List<Integer> rPageIds = runContext.render(this.pageIds).asList(Integer.class);
@@ -192,7 +193,9 @@ public class List extends AbstractConfluenceTask implements RunnableTask<List.Ou
             )
             .collect(Collectors.joining("&"));
 
-        String url = rServerUrl + "/wiki/api/v2/pages";
+        String base = rServerUrl.endsWith("/") ? rServerUrl.substring(0, rServerUrl.length() - 1) : rServerUrl;
+        String apiBase = rApiPath.endsWith("/") ? rApiPath.substring(0, rApiPath.length() - 1) : rApiPath;
+        String url = base + apiBase + "/pages";
         if (!query.isEmpty()) {
             url += "?" + query;
         }

--- a/src/main/java/io/kestra/plugin/confluence/pages/Update.java
+++ b/src/main/java/io/kestra/plugin/confluence/pages/Update.java
@@ -134,6 +134,7 @@ public class Update extends AbstractConfluenceTask implements RunnableTask<Updat
             .orElseThrow(() -> new IllegalArgumentException("username is required"));
         String rApiToken = runContext.render(this.apiToken).as(String.class)
             .orElseThrow(() -> new IllegalArgumentException("apiToken is required"));
+        String rApiPath = runContext.render(this.apiPath).as(String.class).orElse("/wiki/api/v2");
         String rPageId = runContext.render(this.pageId).as(String.class)
             .orElseThrow(() -> new IllegalArgumentException("pageId is required"));
         String rStatus = runContext.render(this.status).as(String.class)
@@ -207,7 +208,8 @@ public class Update extends AbstractConfluenceTask implements RunnableTask<Updat
         String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes());
 
         String base = rServerUrl.endsWith("/") ? rServerUrl.substring(0, rServerUrl.length() - 1) : rServerUrl;
-        String url = base + "/wiki/api/v2/pages/" + rPageId;
+        String apiBase = rApiPath.endsWith("/") ? rApiPath.substring(0, rApiPath.length() - 1) : rApiPath;
+        String url = base + apiBase + "/pages/" + rPageId;
 
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder()

--- a/src/main/java/io/kestra/plugin/confluence/pages/Update.java
+++ b/src/main/java/io/kestra/plugin/confluence/pages/Update.java
@@ -128,13 +128,11 @@ public class Update extends AbstractConfluenceTask implements RunnableTask<Updat
     public Update.Output run(RunContext runContext) throws Exception {
         var logger = runContext.logger();
 
-        String rServerUrl = runContext.render(this.serverUrl).as(String.class)
-            .orElseThrow(() -> new IllegalArgumentException("serverUrl is required"));
+        String apiBaseUrl = buildApiBaseUrl(runContext);
         String rUsername = runContext.render(this.username).as(String.class)
             .orElseThrow(() -> new IllegalArgumentException("username is required"));
         String rApiToken = runContext.render(this.apiToken).as(String.class)
             .orElseThrow(() -> new IllegalArgumentException("apiToken is required"));
-        String rApiPath = runContext.render(this.apiPath).as(String.class).orElse("/wiki/api/v2");
         String rPageId = runContext.render(this.pageId).as(String.class)
             .orElseThrow(() -> new IllegalArgumentException("pageId is required"));
         String rStatus = runContext.render(this.status).as(String.class)
@@ -207,9 +205,7 @@ public class Update extends AbstractConfluenceTask implements RunnableTask<Updat
         String auth = rUsername + ":" + rApiToken;
         String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes());
 
-        String base = rServerUrl.endsWith("/") ? rServerUrl.substring(0, rServerUrl.length() - 1) : rServerUrl;
-        String apiBase = rApiPath.endsWith("/") ? rApiPath.substring(0, rApiPath.length() - 1) : rApiPath;
-        String url = base + apiBase + "/pages/" + rPageId;
+        String url = apiBaseUrl + "/pages/" + rPageId;
 
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder()


### PR DESCRIPTION
## Summary
- Add optional `apiPath` property to `AbstractConfluenceTask` (defaults to `/wiki/api/v2`)
- Replace hardcoded API path in `Create`, `List`, and `Update` tasks with rendered `apiPath`
- Normalize trailing slashes on both `serverUrl` and `apiPath` before building URLs

Closes https://github.com/kestra-io/plugin-confluence/issues/33

## Test plan
- [x] All 19 existing tests pass (default path unchanged)
- [ ] Verify On-Premise instance works with custom `apiPath` (e.g., `/rest/api`)