### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/confluence/AbstractConfluenceTask.java
+++ b/src/main/java/io/kestra/plugin/confluence/AbstractConfluenceTask.java
@@ -42,6 +42,7 @@ public abstract class AbstractConfluenceTask extends Task {
     )
     @NotNull
     @PluginProperty(secret = true, group = "main")
+    @ToString.Exclude
     protected Property<String> username;
 
     @Schema(
@@ -50,6 +51,7 @@ public abstract class AbstractConfluenceTask extends Task {
     )
     @NotNull
     @PluginProperty(secret = true, group = "main")
+    @ToString.Exclude
     protected Property<String> apiToken;
 
     protected String buildApiBaseUrl(RunContext runContext) throws Exception {

--- a/src/main/java/io/kestra/plugin/confluence/pages/List.java
+++ b/src/main/java/io/kestra/plugin/confluence/pages/List.java
@@ -198,7 +198,7 @@ public class List extends AbstractConfluenceTask implements RunnableTask<List.Ou
         }
 
         String auth = rUsername + ":" + rApiToken;
-        String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes());
+        String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
 
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder()

--- a/src/main/java/io/kestra/plugin/confluence/pages/Update.java
+++ b/src/main/java/io/kestra/plugin/confluence/pages/Update.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 
@@ -204,7 +205,7 @@ public class Update extends AbstractConfluenceTask implements RunnableTask<Updat
         }
 
         String auth = rUsername + ":" + rApiToken;
-        String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes());
+        String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
 
         String url = apiBaseUrl + "/pages/" + rPageId;
 


### PR DESCRIPTION
## Summary

Remediates all findings from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** Credential fields username and apiToken not excluded from Lombok @ToString (`src/main/java/io/kestra/plugin/confluence/AbstractConfluenceTask.java:18`)
  - Fix: Added `@ToString.Exclude` to both `username` and `apiToken` fields to prevent plaintext credential exposure in `toString()` output

- **LOW** Basic auth credential string encoded with platform-default charset instead of UTF-8 in Update and List tasks (`src/main/java/io/kestra/plugin/confluence/pages/Update.java:206`)
  - Fix: Replaced `auth.getBytes()` with `auth.getBytes(StandardCharsets.UTF_8)` in both `Update.java` and `List.java` to ensure consistent encoding regardless of JVM locale

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests
- [ ] Manually verified the patched code paths

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-confluence/issues/54
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)

---
*Automated security fix — please review each change carefully before merging.*
