### PR TITLE
docs(confluence): fix example YAML and mark required page fields

### DIFF
--- a/src/main/java/io/kestra/plugin/confluence/pages/Create.java
+++ b/src/main/java/io/kestra/plugin/confluence/pages/Create.java
@@ -52,7 +52,7 @@ import io.kestra.core.models.annotations.PluginProperty;
                     type: io.kestra.plugin.confluence.pages.Create
                     serverUrl: https://your-domain.atlassian.net
                     username: your-email@example.com
-                    apiToken: {{ secret('CONFLUENCE_API_TOKEN') }}
+                    apiToken: "{{ secret('CONFLUENCE_API_TOKEN') }}"
                     spaceId: "123456"
                     title: My New Page from Kestra
                     markdown: |
@@ -100,7 +100,7 @@ public class Create extends AbstractConfluenceTask implements RunnableTask<Creat
 
     @Schema(
         title = "Page title",
-        description = "Display title for the new Confluence page."
+        description = "Display title for the new Confluence page. Required."
     )
     @PluginProperty(group = "advanced")
     private Property<String> title;
@@ -114,7 +114,7 @@ public class Create extends AbstractConfluenceTask implements RunnableTask<Creat
 
     @Schema(
         title = "Markdown content to upload",
-        description = "Markdown rendered to Confluence storage HTML before sending to the API."
+        description = "Markdown rendered to Confluence storage HTML before sending to the API. Required."
     )
     @PluginProperty(group = "advanced")
     private Property<String> markdown;

--- a/src/main/java/io/kestra/plugin/confluence/pages/Update.java
+++ b/src/main/java/io/kestra/plugin/confluence/pages/Update.java
@@ -56,7 +56,8 @@ import io.kestra.core.models.annotations.PluginProperty;
                     status: current
                     title: New Page Title
                     markdown: |
-                      # My Updated Content\\nThis is the new content for the page.
+                      # My Updated Content
+                      This is the new content for the page.
                     versionInfo:
                       number: 2
                       message: Updated content and title via Kestra.


### PR DESCRIPTION
## Documentation review: plugin-confluence

Task-level doc pass over the three tasks (`pages.Create`, `pages.List`, `pages.Update`), the shared `AbstractConfluenceTask`, the two metadata YAMLs, and the how-to doc. Documentation only; no runtime behavior changes.

### Fixes
- **`pages.Create` example** — `apiToken: {{ secret('CONFLUENCE_API_TOKEN') }}` was **unquoted**; a YAML value starting with `{` is a flow-mapping indicator, so it fails to parse. Quoted it (as `List`/`Update` already do).
- **`pages.Update` example** — the `markdown: |` block contained `# My Updated Content\nThis is the new content…` with a literal `\n`. Inside a YAML literal block scalar `\n` is the two characters backslash-n, not a line break, so the rendered page would contain a literal `\n`. Split it onto two lines.
- **`pages.Create`** — `title` and `markdown` are de-facto required (`run()` calls `.orElseThrow()` and the class description says "Requires spaceId, title, markdown"), so added "Required." to their `@Schema` descriptions.

Everything else was accurate: `username`/`apiToken` correctly `@NotNull` + `secret = true`, `Update` correctly marks its required fields `@NotNull`, `List` fetchType/filters/outputs are well documented, and the metadata YAMLs + how-to match the source. No `@Metric` declared or emitted.

---

## 🚩 Engineering flags (optional — not addressed here)
- **`pages.Create.title` and `pages.Create.markdown`** — required at runtime (`orElseThrow`) but not annotated `@NotNull`, and placed in `@PluginProperty(group = "advanced")` alongside truly-optional flags; consider `@NotNull` + `group = "main"` so the schema/UI reflect that they are required core inputs (`spaceId` already uses `@NotNull` + `requiredMode = REQUIRED`).
- **`AbstractConfluenceTask.username`** is marked `secret = true`. Masking an account email is unusual (usually only `apiToken` is secret); confirm intentional or drop `secret = true` on `username`.